### PR TITLE
Fix the issue where prompts cannot be inserted for filepath that contains ampersand

### DIFF
--- a/javascript/lora_prompt_tool.js
+++ b/javascript/lora_prompt_tool.js
@@ -326,6 +326,7 @@ onUiLoaded(() => {
                     
                     model_path = model_path.replace(/(\.(bin|pt|safetensors|ckpt))(\s+)?([a-z0-9]+)?$/i, "$1");
                     model_path = model_path.replace(/\\/g, '\\\\');
+                    model_path = model_path.replace(/&amp;/g, '&');
 
                     var slashIndex = model_path.indexOf("\\");
                     if (slashIndex !== -1) {


### PR DESCRIPTION
Ampersands in filepath are HTML encoded, so have to decode.